### PR TITLE
update of referenced libraries

### DIFF
--- a/Dbosoft.Functional.sln
+++ b/Dbosoft.Functional.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dbosoft.Functional", "src\Dbosoft.Functional\Dbosoft.Functional.csproj", "{D38F1C28-A069-4E32-81FA-1F3F1C7F3619}"
 EndProject

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,0 +1,6 @@
+assembly-versioning-scheme: MajorMinor
+mode: ContinuousDeployment
+branches: {}
+ignore:
+  sha: []
+merge-message-formats: {}

--- a/src/Dbosoft.Functional/Dbosoft.Functional.csproj
+++ b/src/Dbosoft.Functional/Dbosoft.Functional.csproj
@@ -15,12 +15,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="4.0.0">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="LanguageExt.Core" Version="3.0.28" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="LanguageExt.Core" Version="3.4.15" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- GitVersionTask is deprecated - use GitVersion.MsBuild
- updated languageex to 3.4.15
- update System.Threading.Tasks.Dataflow to 5.0.0

consider as breaking as dependencies changed a lot and may cause a breaking change.

+semver: breaking