### PR TITLE
use with EitherAsync is disposed to early

### DIFF
--- a/src/Dbosoft.Functional/UseExtensions.cs
+++ b/src/Dbosoft.Functional/UseExtensions.cs
@@ -11,8 +11,8 @@ namespace LanguageExt
     {
         public static EitherAsync<L, R2> Use<L, R1, R2>(this EitherAsync<L, R1> self, Func<EitherAsync<L, R1>, EitherAsync<L, R2>> map) where R1 : IDisposable
         {
-            var res = self.Bind(f => use(f, f1 => map(self)));
-            return res;
+            var res = self.ToEither().BindAsync(f => use(f, f1 => map(self).ToEither()));
+            return res.ToAsync();
         }
 
         public static Task<Either<L, R2>> Use<L, R1, R2>(this Task<Either<L, R1>> self, Func<Task<Either<L, R1>>, Task<Either<L, R2>>> map) where R1 : IDisposable


### PR DESCRIPTION
when using use with EitherAsync the task is disposed to early
changed implemention to wrap it into Task<Either<,>>