### PR TITLE
Add JSON support for LanguageExt NewType

### DIFF
--- a/Dbosoft.Functional.sln
+++ b/Dbosoft.Functional.sln
@@ -7,6 +7,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dbosoft.Functional", "src\D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dbosoft.Functional.Tests", "test\Dbosoft.Functional.Tests\Dbosoft.Functional.Tests.csproj", "{ADA73324-0DE5-479D-A63B-888EB922984E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dbosoft.Functional.Json", "src\Dbosoft.Functional.Json\Dbosoft.Functional.Json.csproj", "{1060C36D-CF26-4932-A9E6-F2C5BC32B8B7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dbosoft.Functional.Json.Tests", "test\Dbosoft.Functional.Json.Tests\Dbosoft.Functional.Json.Tests.csproj", "{E6E91D63-DB2C-4B6F-A701-4F1BA558AB0F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +25,14 @@ Global
 		{ADA73324-0DE5-479D-A63B-888EB922984E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADA73324-0DE5-479D-A63B-888EB922984E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADA73324-0DE5-479D-A63B-888EB922984E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1060C36D-CF26-4932-A9E6-F2C5BC32B8B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1060C36D-CF26-4932-A9E6-F2C5BC32B8B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1060C36D-CF26-4932-A9E6-F2C5BC32B8B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1060C36D-CF26-4932-A9E6-F2C5BC32B8B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6E91D63-DB2C-4B6F-A701-4F1BA558AB0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6E91D63-DB2C-4B6F-A701-4F1BA558AB0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6E91D63-DB2C-4B6F-A701-4F1BA558AB0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6E91D63-DB2C-4B6F-A701-4F1BA558AB0F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,10 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
+- task: UseGitVersion@5
+  inputs:
+    versionSpec: '5.11.x'
+
 - task: DotNetCoreCLI@2
   inputs:
     command: restore

--- a/src/Dbosoft.Functiona.Json/Dbosoft.Functiona.Json.csproj
+++ b/src/Dbosoft.Functiona.Json/Dbosoft.Functiona.Json.csproj
@@ -1,7 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-
-</Project>

--- a/src/Dbosoft.Functiona.Json/Dbosoft.Functiona.Json.csproj
+++ b/src/Dbosoft.Functiona.Json/Dbosoft.Functiona.Json.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Dbosoft.Functional.Json/DataTypes/NewTypeJsonConverter.cs
+++ b/src/Dbosoft.Functional.Json/DataTypes/NewTypeJsonConverter.cs
@@ -7,7 +7,23 @@ using LanguageExt.TypeClasses;
 namespace Dbosoft.Functional.Json.DataTypes;
 
 /// <summary>
-/// 
+/// <para>
+/// A JSON converter which supports <see cref="NewType{NEWTYPE,A, PRED, ORD}"/>.
+/// </para>
+/// <para>
+/// The <see cref="NewType{NEWTYPE,A, PRED, ORD}"/> must be based on one of the
+/// following types: <type><see cref="string"/></type>,
+/// <type><see cref="bool"/></type>, <type><see cref="short"/></type>
+/// <type><see cref="int"/></type>, <type><see cref="long"/></type>
+/// <type><see cref="byte"/></type>, <type><see cref="ushort"/></type>
+/// <type><see cref="uint"/></type>, <type><see cref="ulong"/></type>,
+/// <type><see cref="float"/></type>, <type><see cref="double"/></type>,
+/// <type><see cref="decimal"/></type>.
+/// </para>
+/// <para>
+/// <see cref="NewType{NEWTYPE,A, PRED, ORD}"/>s with <see cref="String"/> as
+/// the base value can be used as keys in dictionaries, objects, etc.
+/// </para>
 /// </summary>
 public class NewTypeJsonConverter : JsonConverterFactory
 {

--- a/src/Dbosoft.Functional.Json/DataTypes/NewTypeJsonConverter.cs
+++ b/src/Dbosoft.Functional.Json/DataTypes/NewTypeJsonConverter.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LanguageExt;
+using LanguageExt.TypeClasses;
+
+namespace Dbosoft.Functional.Json.DataTypes;
+
+/// <summary>
+/// 
+/// </summary>
+public class NewTypeJsonConverter : JsonConverterFactory
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type typeToConvert)
+    {
+        var newType = FindNewType(typeToConvert);
+        if (newType is null || !newType.IsGenericType || newType.GetGenericTypeDefinition() != typeof(NewType<,,,>))
+            return false;
+
+        var arguments = newType.GetGenericArguments();
+        if (arguments.Length != 4)
+            return false;
+
+        var a = arguments[1];
+        return a == typeof(string)
+               || a == typeof(bool)
+               || a == typeof(short)
+               || a == typeof(int)
+               || a == typeof(long)
+               || a == typeof(ushort)
+               || a == typeof(uint)
+               || a == typeof(ulong)
+               || a == typeof(float)
+               || a == typeof(double)
+               || a == typeof(decimal);
+    }
+
+    /// <inheritdoc />
+    public override JsonConverter CreateConverter(
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        var newType = FindNewType(typeToConvert);
+        if (newType is null || !newType.IsGenericType || newType.GetGenericTypeDefinition() != typeof(NewType<,,,>))
+            throw new ArgumentException("The type is not a LanguageExt NewType.", nameof(typeToConvert));
+
+        var arguments = newType.GetGenericArguments();
+        var a = arguments[1];
+        var pred = arguments[2];
+        var ord = arguments[3];
+
+        if (a == typeof(string))
+        {
+            return (JsonConverter)Activator.CreateInstance(
+                typeof(NewTypeJsonConverter<,,,>)
+                    .MakeGenericType(typeToConvert, typeToConvert, pred, ord));
+        }
+
+        if (a == typeof(bool) || a == typeof(short) || a == typeof(int) || a == typeof(long)
+            || a == typeof(ushort) || a == typeof(uint) || a == typeof(ulong)
+            || a == typeof(float) || a == typeof(double) || a == typeof(decimal))
+        {
+            return (JsonConverter)Activator.CreateInstance(
+                typeof(NewTypeJsonConverter<,,,,>)
+                    .MakeGenericType(typeToConvert, typeToConvert, a, pred, ord));
+        }
+
+        throw new ArgumentException($"The value type {a.Name} is not supported.", nameof(typeToConvert));
+    }
+
+    private static Type? FindNewType(Type type)
+    {
+        var candidate = type;
+        while (candidate is not null && candidate != typeof(object))
+        {
+            if (candidate.IsGenericType && candidate.GetGenericTypeDefinition() == typeof(NewType<,,,>))
+                return candidate;
+            candidate = candidate.BaseType;
+        }
+
+        return null;
+    }
+}
+
+internal class NewTypeJsonConverter<T, NEWTYPE, PRED, ORD>
+    : JsonConverter<T>
+    where T : NewType<NEWTYPE, string, PRED, ORD>
+    where PRED : struct, Pred<string>
+    where NEWTYPE : NewType<NEWTYPE, string, PRED, ORD>
+    where ORD : struct, Ord<string>
+{
+    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return (T)Activator.CreateInstance(typeToConvert, reader.GetString());
+    }
+
+    public override T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return (T)Activator.CreateInstance(typeToConvert, reader.GetString());
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.Value);
+    }
+
+    public override void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        writer.WritePropertyName(value.Value);
+    }
+}
+
+internal class NewTypeJsonConverter<T, NEWTYPE, A, PRED, ORD>
+    : JsonConverter<T>
+    where T : NewType<NEWTYPE, A, PRED, ORD>
+    where PRED : struct, Pred<A>
+    where NEWTYPE : NewType<NEWTYPE, A, PRED, ORD>
+    where ORD : struct, Ord<A>
+{
+    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        object? value = typeof(A) switch
+        {
+            { } t when t == typeof(bool) => reader.GetBoolean(),
+            { } t when t == typeof(byte) => reader.GetByte(),
+            { } t when t == typeof(short) => reader.GetInt16(),
+            { } t when t == typeof(int) => reader.GetInt32(),
+            { } t when t == typeof(long) => reader.GetInt64(),
+            { } t when t == typeof(ushort) => reader.GetUInt16(),
+            { } t when t == typeof(uint) => reader.GetUInt32(),
+            { } t when t == typeof(ulong) => reader.GetUInt64(),
+            { } t when t == typeof(float) => reader.GetSingle(),
+            { } t when t == typeof(double) => reader.GetDouble(),
+            { } t when t == typeof(decimal) => reader.GetDecimal(),
+            _ => throw new InvalidOperationException($"Values of type {typeof(A).Name} are not supported.")
+        };
+        return (T)Activator.CreateInstance(typeToConvert, value);
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        switch (value.Value)
+        {
+            case bool v:
+                writer.WriteBooleanValue(v);
+                return;
+            case byte v:
+                writer.WriteNumberValue(v);
+                return;
+            case short v:
+                writer.WriteNumberValue(v);
+                return;
+            case int v:
+                writer.WriteNumberValue(v);
+                return;
+            case long v:
+                writer.WriteNumberValue(v);
+                return;
+            case ushort v:
+                writer.WriteNumberValue(v);
+                return;
+            case uint v:
+                writer.WriteNumberValue(v);
+                return;
+            case ulong v:
+                writer.WriteNumberValue(v);
+                break;
+            case float v:
+                writer.WriteNumberValue(v);
+                return;
+            case double v:
+                writer.WriteNumberValue(v);
+                return;
+            case decimal v:
+                writer.WriteNumberValue(v);
+                return;
+            default:
+                throw new ArgumentException("Values this type are not supported.", nameof(value));
+        }
+    }
+}

--- a/src/Dbosoft.Functional.Json/DataTypes/NewTypeJsonConverter.cs
+++ b/src/Dbosoft.Functional.Json/DataTypes/NewTypeJsonConverter.cs
@@ -21,7 +21,7 @@ namespace Dbosoft.Functional.Json.DataTypes;
 /// <type><see cref="decimal"/></type>.
 /// </para>
 /// <para>
-/// <see cref="NewType{NEWTYPE,A, PRED, ORD}"/>s with <see cref="String"/> as
+/// <see cref="NewType{NEWTYPE,A, PRED, ORD}"/>s with <see cref="string"/> as
 /// the base value can be used as keys in dictionaries, objects, etc.
 /// </para>
 /// </summary>
@@ -185,7 +185,7 @@ internal class NewTypeJsonConverter<T, NEWTYPE, A, PRED, ORD>
                 writer.WriteNumberValue(v);
                 return;
             default:
-                throw new ArgumentException("Values this type are not supported.", nameof(value));
+                throw new ArgumentException("Values of this type are not supported.", nameof(value));
         }
     }
 }

--- a/src/Dbosoft.Functional.Json/DataTypes/NewTypeJsonConverter.cs
+++ b/src/Dbosoft.Functional.Json/DataTypes/NewTypeJsonConverter.cs
@@ -23,17 +23,10 @@ public class NewTypeJsonConverter : JsonConverterFactory
             return false;
 
         var a = arguments[1];
-        return a == typeof(string)
-               || a == typeof(bool)
-               || a == typeof(short)
-               || a == typeof(int)
-               || a == typeof(long)
-               || a == typeof(ushort)
-               || a == typeof(uint)
-               || a == typeof(ulong)
-               || a == typeof(float)
-               || a == typeof(double)
-               || a == typeof(decimal);
+        return a == typeof(string) || a == typeof(bool)
+               || a == typeof(short) || a == typeof(int) || a == typeof(long)
+               || a == typeof(byte) || a == typeof(ushort) || a == typeof(uint) || a == typeof(ulong)
+               || a == typeof(float) || a == typeof(double) || a == typeof(decimal);
     }
 
     /// <inheritdoc />
@@ -58,7 +51,7 @@ public class NewTypeJsonConverter : JsonConverterFactory
         }
 
         if (a == typeof(bool) || a == typeof(short) || a == typeof(int) || a == typeof(long)
-            || a == typeof(ushort) || a == typeof(uint) || a == typeof(ulong)
+            || a == typeof(byte) || a == typeof(ushort) || a == typeof(uint) || a == typeof(ulong)
             || a == typeof(float) || a == typeof(double) || a == typeof(decimal))
         {
             return (JsonConverter)Activator.CreateInstance(

--- a/src/Dbosoft.Functional.Json/Dbosoft.Functional.Json.csproj
+++ b/src/Dbosoft.Functional.Json/Dbosoft.Functional.Json.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10</LangVersion>
-	<Nullable>enable</Nullable>
+	  <Nullable>enable</Nullable>
+    <PackageId>Dbosoft.Functional.Json</PackageId>
+    <Description>JSON support for LanguageExt NewType.</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="LanguageExt.Core" Version="[4.4.0,4.5.0)" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dbosoft.Functional.Json/Dbosoft.Functional.Json.csproj
+++ b/src/Dbosoft.Functional.Json/Dbosoft.Functional.Json.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+	<Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LanguageExt.Core" Version="[4.4.0,4.5.0)" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dbosoft.Functional\Dbosoft.Functional.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dbosoft.Functional/Dbosoft.Functional.csproj
+++ b/src/Dbosoft.Functional/Dbosoft.Functional.csproj
@@ -1,42 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10</LangVersion>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/dbosoft/Dbosoft.Functional</PackageProjectUrl>
-    <Copyright>dbosoft GmbH</Copyright>
-    <Authors>dbosoft</Authors>
-    <Company>dbosoft GmbH</Company>
-    <Product>Dbosoft.Functional</Product>
-    <RepositoryUrl>https://github.com/dbosoft/Dbosoft.Functional</RepositoryUrl>
     <PackageId>Dbosoft.Functional</PackageId>
     <Description>Functional helper library based on language.ext.</Description>
-
-    <!-- Declare that the Repository URL can be published to NuSpec -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Embed source files that are not tracked by the source control manager to the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <!-- Include PDB in the built .nupkg -->
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">True</ContinuousIntegrationBuild>
-    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">True</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="LanguageExt.Core" Version="[4.4.0,4.5.0)" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="[5,)" />
   </ItemGroup>
-
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,17 +1,28 @@
-
 <Project>
+
   <PropertyGroup>
-      <!-- Declare that the Repository URL can be published to NuSpec -->
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageProjectUrl>https://github.com/dbosoft/Dbosoft.Functional</PackageProjectUrl>
+    <PackageReleaseNotes>https://github.com/dbosoft/Dbosoft.Functional/releases</PackageReleaseNotes>
+    <Authors>dbosoft GmbH</Authors>
+    <Company>dbosoft GmbH</Company>
+    <Product>Dbosoft.Functional</Product>
+    <Copyright>dbosoft GmbH. All rights reserved.</Copyright>
+    <RepositoryUrl>https://github.com/dbosoft/Dbosoft.Functional</RepositoryUrl>
+    <!-- Declare that the Repository URL can be published to NuSpec -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Embed source files that are not tracked by the source control manager to the PDB -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
   </PropertyGroup>
 
+  <PropertyGroup>
+    <LangVersion>12</LangVersion>
+    <NoWarn>CS1591</NoWarn>
+  </PropertyGroup>
 
   <PropertyGroup>
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">True</ContinuousIntegrationBuild>
@@ -19,6 +30,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.*" PrivateAssets="All"/>
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
+
 </Project>

--- a/test/Dbosoft.Functional.Json.Tests/DataTypes/NewTypeJsonConverterTests.cs
+++ b/test/Dbosoft.Functional.Json.Tests/DataTypes/NewTypeJsonConverterTests.cs
@@ -4,6 +4,7 @@ using Dbosoft.Functional.Json.DataTypes;
 using FluentAssertions;
 using LanguageExt;
 using LanguageExt.ClassInstances;
+using Xunit;
 
 namespace Dbosoft.Functional.Json.Tests.DataTypes;
 
@@ -418,18 +419,18 @@ public class NewTypeJsonConverterTests
         var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
         
         result.Should().Be("""
-                          {
-                            "property": "property-value",
-                            "list": [
-                              "list-item-1",
-                              "list-item-2"
-                            ],
-                            "map": {
-                              "key-1": "map-value-1",
-                              "key-2": "map-value-2"
-                            }
-                          }
-                          """);
+                           {
+                             "property": "property-value",
+                             "list": [
+                               "list-item-1",
+                               "list-item-2"
+                             ],
+                             "map": {
+                               "key-1": "map-value-1",
+                               "key-2": "map-value-2"
+                             }
+                           }
+                           """);
     }
 
     [Fact]
@@ -864,7 +865,9 @@ public class NewTypeJsonConverterTests
     public class KeyTestEntity<TValue>
     {
         public required TValue Property { get; set; }
+
         public required IReadOnlyList<TValue> List { get; set; }
+
         public required IReadOnlyDictionary<TValue, TValue> Map { get; init; }
     }
 

--- a/test/Dbosoft.Functional.Json.Tests/DataTypes/NewTypeJsonConverterTests.cs
+++ b/test/Dbosoft.Functional.Json.Tests/DataTypes/NewTypeJsonConverterTests.cs
@@ -1,0 +1,245 @@
+﻿using Dbosoft.Functional.Json.DataTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Dbosoft.Functional.DataTypes;
+using FluentAssertions;
+using LanguageExt;
+using LanguageExt.ClassInstances;
+
+namespace Dbosoft.Functional.Json.Tests.DataTypes;
+
+public class NewTypeJsonConverterTests
+{
+    private static JsonSerializerOptions Options => new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new NewTypeJsonConverter() },
+    };
+
+    private static JsonSerializerOptions OptionsWithIndent => new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new NewTypeJsonConverter() },
+        WriteIndented = true,
+    };
+
+    [Fact]
+    public void Deserialize_StringNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": "property-value",
+                     "list": [
+                       "list-item-1",
+                       "list-item-2"
+                     ],
+                     "map": {
+                       "key-1": "map-value-1",
+                       "key-2": "map-value-2"
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<KeyTestEntity<TestType<string>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be("property-value");
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be("list-item-1"),
+            item => item.Value.Should().Be("list-item-2"));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey(TestType<string>.New("key-1"))
+            .WhoseValue.Value.Should().Be("map-value-1");
+        result.Map.Should().ContainKey(TestType<string>.New("key-2"))
+            .WhoseValue.Value.Should().Be("map-value-2");
+    }
+
+    [Fact]
+    public void Deserialize_ValidatingNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": "property-value",
+                     "list": [
+                       "list-item-1",
+                       "list-item-2"
+                     ],
+                     "map": {
+                       "key-1": "map-value-1",
+                       "key-2": "map-value-2"
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<KeyTestEntity<ValidatingTestType>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be("property-value");
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be("list-item-1"),
+            item => item.Value.Should().Be("list-item-2"));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey(ValidatingTestType.New("key-1"))
+            .WhoseValue.Value.Should().Be("map-value-1");
+        result.Map.Should().ContainKey(ValidatingTestType.New("key-2"))
+            .WhoseValue.Value.Should().Be("map-value-2");
+    }
+
+    [Fact]
+    public void Deserialize_IntNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 42,
+                     "list": [
+                       43,
+                       -44
+                     ],
+                     "map": {
+                       "key-1": 45,
+                       "key-2": -46
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<int>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(42);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(43),
+            item => item.Value.Should().Be(-44));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(45);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(-46);
+    }
+
+    [Fact]
+    public void Serialize_StringNewType_ReturnsJson()
+    {
+        var entity = new KeyTestEntity<TestType<string>>
+        {
+            Property = TestType<string>.New("property-value"),
+            List =
+            [
+                TestType<string>.New("list-item-1"),
+                TestType<string>.New("list-item-2")
+            ],
+            Map = new Dictionary<TestType<string>, TestType<string>>
+            {
+                [TestType<string>.New("key-1")] = TestType<string>.New("map-value-1"),
+                [TestType<string>.New("key-2")] = TestType<string>.New("map-value-2")
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+        
+        result.Should().Be("""
+                          {
+                            "property": "property-value",
+                            "list": [
+                              "list-item-1",
+                              "list-item-2"
+                            ],
+                            "map": {
+                              "key-1": "map-value-1",
+                              "key-2": "map-value-2"
+                            }
+                          }
+                          """);
+    }
+
+    [Fact]
+    public void Serialize_ValidatingNewType_ReturnsJson()
+    {
+        var entity = new KeyTestEntity<ValidatingTestType>
+        {
+            Property = ValidatingTestType.New("property-value"),
+            List =
+            [
+                ValidatingTestType.New("list-item-1"),
+                ValidatingTestType.New("list-item-2")
+            ],
+            Map = new Dictionary<ValidatingTestType, ValidatingTestType>
+            {
+                [ValidatingTestType.New("key-1")] = ValidatingTestType.New("map-value-1"),
+                [ValidatingTestType.New("key-2")] = ValidatingTestType.New("map-value-2")
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": "property-value",
+                             "list": [
+                               "list-item-1",
+                               "list-item-2"
+                             ],
+                             "map": {
+                               "key-1": "map-value-1",
+                               "key-2": "map-value-2"
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_IntNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<int>>
+        {
+            Property = TestType<int>.New(42),
+            List =
+            [
+                TestType<int>.New(43),
+                TestType<int>.New(-44)
+            ],
+            Map = new Dictionary<string, TestType<int>>
+            {
+                ["key-1"] = TestType<int>.New(45),
+                ["key-2"] = TestType<int>.New(-46)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 42,
+                             "list": [
+                               43,
+                               -44
+                             ],
+                             "map": {
+                               "key-1": 45,
+                               "key-2": -46
+                             }
+                           }
+                           """);
+    }
+
+    public class TestType<TValue>(TValue value) : NewType<TestType<TValue>, TValue>(value)
+    {
+    }
+
+    public class ValidatingTestType(string value)
+        : ValidatingNewType<ValidatingTestType, string, OrdStringOrdinalIgnoreCase>(value)
+    {
+    }
+
+    public class KeyTestEntity<TValue>
+    {
+        public required TValue Property { get; set; }
+        public required IReadOnlyList<TValue> List { get; set; }
+        public required IReadOnlyDictionary<TValue, TValue> Map { get; init; }
+    }
+
+    public class TestEntity<TValue>
+    {
+        public required TValue Property { get; set; }
+
+        public required IReadOnlyList<TValue> List { get; set; }
+
+        public required IReadOnlyDictionary<string, TValue> Map { get; init; }
+    }
+}
+

--- a/test/Dbosoft.Functional.Json.Tests/DataTypes/NewTypeJsonConverterTests.cs
+++ b/test/Dbosoft.Functional.Json.Tests/DataTypes/NewTypeJsonConverterTests.cs
@@ -1,11 +1,6 @@
-﻿using Dbosoft.Functional.Json.DataTypes;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
+﻿using System.Text.Json;
 using Dbosoft.Functional.DataTypes;
+using Dbosoft.Functional.Json.DataTypes;
 using FluentAssertions;
 using LanguageExt;
 using LanguageExt.ClassInstances;

--- a/test/Dbosoft.Functional.Json.Tests/DataTypes/NewTypeJsonConverterTests.cs
+++ b/test/Dbosoft.Functional.Json.Tests/DataTypes/NewTypeJsonConverterTests.cs
@@ -84,6 +84,64 @@ public class NewTypeJsonConverterTests
     }
 
     [Fact]
+    public void Deserialize_BoolNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": true,
+                     "list": [
+                       true,
+                       false
+                     ],
+                     "map": {
+                       "key-1": true,
+                       "key-2": false
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<bool>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(true);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(true),
+            item => item.Value.Should().Be(false));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(true);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(false);
+    }
+
+    [Fact]
+    public void Deserialize_ShortNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 42,
+                     "list": [
+                       43,
+                       -44
+                     ],
+                     "map": {
+                       "key-1": 45,
+                       "key-2": -46
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<short>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(42);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(43),
+            item => item.Value.Should().Be(-44));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(45);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(-46);
+    }
+
+    [Fact]
     public void Deserialize_IntNewType_ReturnsData()
     {
         var json = """
@@ -110,6 +168,238 @@ public class NewTypeJsonConverterTests
             .WhoseValue.Value.Should().Be(45);
         result.Map.Should().ContainKey("key-2")
             .WhoseValue.Value.Should().Be(-46);
+    }
+
+    [Fact]
+    public void Deserialize_LongNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 42,
+                     "list": [
+                       43,
+                       -44
+                     ],
+                     "map": {
+                       "key-1": 45,
+                       "key-2": -46
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<long>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(42);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(43),
+            item => item.Value.Should().Be(-44));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(45);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(-46);
+    }
+
+    [Fact]
+    public void Deserialize_ByteShortNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 42,
+                     "list": [
+                       43,
+                       44
+                     ],
+                     "map": {
+                       "key-1": 45,
+                       "key-2": 46
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<byte>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(42);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(43),
+            item => item.Value.Should().Be(44));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(45);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(46);
+    }
+
+    [Fact]
+    public void Deserialize_UnsignedShortNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 42,
+                     "list": [
+                       43,
+                       44
+                     ],
+                     "map": {
+                       "key-1": 45,
+                       "key-2": 46
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<ushort>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(42);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(43),
+            item => item.Value.Should().Be(44));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(45);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(46);
+    }
+
+    [Fact]
+    public void Deserialize_UnsignedIntNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 42,
+                     "list": [
+                       43,
+                       44
+                     ],
+                     "map": {
+                       "key-1": 45,
+                       "key-2": 46
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<uint>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(42);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(43),
+            item => item.Value.Should().Be(44));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(45);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(46);
+    }
+
+    [Fact]
+    public void Deserialize_UnsignedLongNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 42,
+                     "list": [
+                       43,
+                       44
+                     ],
+                     "map": {
+                       "key-1": 45,
+                       "key-2": 46
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<ulong>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(42);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(43),
+            item => item.Value.Should().Be(44));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(45);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(46);
+    }
+
+    [Fact]
+    public void Deserialize_FloatNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 4.2,
+                     "list": [
+                       4.3,
+                       -4.4
+                     ],
+                     "map": {
+                       "key-1": 4.5,
+                       "key-2": -4.6
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<float>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(4.2f);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(4.3f),
+            item => item.Value.Should().Be(-4.4f));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(4.5f);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(-4.6f);
+    }
+
+    [Fact]
+    public void Deserialize_DoubleNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 4.2,
+                     "list": [
+                       4.3,
+                       -4.4
+                     ],
+                     "map": {
+                       "key-1": 4.5,
+                       "key-2": -4.6
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<double>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(4.2);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(4.3),
+            item => item.Value.Should().Be(-4.4));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(4.5);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(-4.6);
+    }
+
+    [Fact]
+    public void Deserialize_DecimalNewType_ReturnsData()
+    {
+        var json = """
+                   {
+                     "property": 4.2,
+                     "list": [
+                       4.3,
+                       -4.4
+                     ],
+                     "map": {
+                       "key-1": 4.5,
+                       "key-2": -4.6
+                     }
+                   }
+                   """;
+        var result = JsonSerializer.Deserialize<TestEntity<TestType<decimal>>>(json, Options);
+        result.Should().NotBeNull();
+        result!.Property.Value.Should().Be(4.2m);
+        result.List.Should().SatisfyRespectively(
+            item => item.Value.Should().Be(4.3m),
+            item => item.Value.Should().Be(-4.4m));
+        result.Map.Should().HaveCount(2);
+        result.Map.Should().ContainKey("key-1")
+            .WhoseValue.Value.Should().Be(4.5m);
+        result.Map.Should().ContainKey("key-2")
+            .WhoseValue.Value.Should().Be(-4.6m);
     }
 
     [Fact]
@@ -183,6 +473,76 @@ public class NewTypeJsonConverterTests
     }
 
     [Fact]
+    public void Serialize_BoolNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<bool>>
+        {
+            Property = TestType<bool>.New(true),
+            List =
+            [
+                TestType<bool>.New(true),
+                TestType<bool>.New(false)
+            ],
+            Map = new Dictionary<string, TestType<bool>>
+            {
+                ["key-1"] = TestType<bool>.New(true),
+                ["key-2"] = TestType<bool>.New(false)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": true,
+                             "list": [
+                               true,
+                               false
+                             ],
+                             "map": {
+                               "key-1": true,
+                               "key-2": false
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_ShortNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<short>>
+        {
+            Property = TestType<short>.New(42),
+            List =
+            [
+                TestType<short>.New(43),
+                TestType<short>.New(-44)
+            ],
+            Map = new Dictionary<string, TestType<short>>
+            {
+                ["key-1"] = TestType<short>.New(45),
+                ["key-2"] = TestType<short>.New(-46)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 42,
+                             "list": [
+                               43,
+                               -44
+                             ],
+                             "map": {
+                               "key-1": 45,
+                               "key-2": -46
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
     public void Serialize_IntNewType_ReturnsJson()
     {
         var entity = new TestEntity<TestType<int>>
@@ -212,6 +572,286 @@ public class NewTypeJsonConverterTests
                              "map": {
                                "key-1": 45,
                                "key-2": -46
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_LongNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<long>>
+        {
+            Property = TestType<long>.New(42),
+            List =
+            [
+                TestType<long>.New(43),
+                TestType<long>.New(-44)
+            ],
+            Map = new Dictionary<string, TestType<long>>
+            {
+                ["key-1"] = TestType<long>.New(45),
+                ["key-2"] = TestType<long>.New(-46)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 42,
+                             "list": [
+                               43,
+                               -44
+                             ],
+                             "map": {
+                               "key-1": 45,
+                               "key-2": -46
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_ByteNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<byte>>
+        {
+            Property = TestType<byte>.New(42),
+            List =
+            [
+                TestType<byte>.New(43),
+                TestType<byte>.New(44)
+            ],
+            Map = new Dictionary<string, TestType<byte>>
+            {
+                ["key-1"] = TestType<byte>.New(45),
+                ["key-2"] = TestType<byte>.New(46)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 42,
+                             "list": [
+                               43,
+                               44
+                             ],
+                             "map": {
+                               "key-1": 45,
+                               "key-2": 46
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_UnsignedShortNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<ushort>>
+        {
+            Property = TestType<ushort>.New(42),
+            List =
+            [
+                TestType<ushort>.New(43),
+                TestType<ushort>.New(44)
+            ],
+            Map = new Dictionary<string, TestType<ushort>>
+            {
+                ["key-1"] = TestType<ushort>.New(45),
+                ["key-2"] = TestType<ushort>.New(46)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 42,
+                             "list": [
+                               43,
+                               44
+                             ],
+                             "map": {
+                               "key-1": 45,
+                               "key-2": 46
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_UnsignedIntNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<uint>>
+        {
+            Property = TestType<uint>.New(42),
+            List =
+            [
+                TestType<uint>.New(43),
+                TestType<uint>.New(44)
+            ],
+            Map = new Dictionary<string, TestType<uint>>
+            {
+                ["key-1"] = TestType<uint>.New(45),
+                ["key-2"] = TestType<uint>.New(46)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 42,
+                             "list": [
+                               43,
+                               44
+                             ],
+                             "map": {
+                               "key-1": 45,
+                               "key-2": 46
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_UnsignedLongNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<ulong>>
+        {
+            Property = TestType<ulong>.New(42),
+            List =
+            [
+                TestType<ulong>.New(43),
+                TestType<ulong>.New(44)
+            ],
+            Map = new Dictionary<string, TestType<ulong>>
+            {
+                ["key-1"] = TestType<ulong>.New(45),
+                ["key-2"] = TestType<ulong>.New(46)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 42,
+                             "list": [
+                               43,
+                               44
+                             ],
+                             "map": {
+                               "key-1": 45,
+                               "key-2": 46
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_FloatNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<float>>
+        {
+            Property = TestType<float>.New(4.2f),
+            List =
+            [
+                TestType<float>.New(4.3f),
+                TestType<float>.New(-4.4f)
+            ],
+            Map = new Dictionary<string, TestType<float>>
+            {
+                ["key-1"] = TestType<float>.New(4.5f),
+                ["key-2"] = TestType<float>.New(-4.6f)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 4.2,
+                             "list": [
+                               4.3,
+                               -4.4
+                             ],
+                             "map": {
+                               "key-1": 4.5,
+                               "key-2": -4.6
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_DoubleNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<double>>
+        {
+            Property = TestType<double>.New(4.2),
+            List =
+            [
+                TestType<double>.New(4.3),
+                TestType<double>.New(-4.4)
+            ],
+            Map = new Dictionary<string, TestType<double>>
+            {
+                ["key-1"] = TestType<double>.New(4.5),
+                ["key-2"] = TestType<double>.New(-4.6)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 4.2,
+                             "list": [
+                               4.3,
+                               -4.4
+                             ],
+                             "map": {
+                               "key-1": 4.5,
+                               "key-2": -4.6
+                             }
+                           }
+                           """);
+    }
+
+    [Fact]
+    public void Serialize_DecimalNewType_ReturnsJson()
+    {
+        var entity = new TestEntity<TestType<decimal>>
+        {
+            Property = TestType<decimal>.New(4.2m),
+            List =
+            [
+                TestType<decimal>.New(4.3m),
+                TestType<decimal>.New(-4.4m)
+            ],
+            Map = new Dictionary<string, TestType<decimal>>
+            {
+                ["key-1"] = TestType<decimal>.New(4.5m),
+                ["key-2"] = TestType<decimal>.New(-4.6m)
+            }
+        };
+
+        var result = JsonSerializer.Serialize(entity, OptionsWithIndent);
+
+        result.Should().Be("""
+                           {
+                             "property": 4.2,
+                             "list": [
+                               4.3,
+                               -4.4
+                             ],
+                             "map": {
+                               "key-1": 4.5,
+                               "key-2": -4.6
                              }
                            }
                            """);

--- a/test/Dbosoft.Functional.Json.Tests/Dbosoft.Functional.Json.Tests.csproj
+++ b/test/Dbosoft.Functional.Json.Tests/Dbosoft.Functional.Json.Tests.csproj
@@ -26,8 +26,4 @@
     <ProjectReference Include="..\..\src\Dbosoft.Functional.Json\Dbosoft.Functional.Json.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
-
 </Project>

--- a/test/Dbosoft.Functional.Json.Tests/Dbosoft.Functional.Json.Tests.csproj
+++ b/test/Dbosoft.Functional.Json.Tests/Dbosoft.Functional.Json.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -15,9 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="FluentAssertions.LanguageExt" Version="0.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
@@ -26,7 +23,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Dbosoft.Functional\Dbosoft.Functional.csproj" />
+    <ProjectReference Include="..\..\src\Dbosoft.Functional.Json\Dbosoft.Functional.Json.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/test/Dbosoft.Functional.Json.Tests/Dbosoft.Functional.Json.Tests.csproj
+++ b/test/Dbosoft.Functional.Json.Tests/Dbosoft.Functional.Json.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/test/Dbosoft.Functional.Tests/Dbosoft.Functional.Tests.csproj
+++ b/test/Dbosoft.Functional.Tests/Dbosoft.Functional.Tests.csproj
@@ -14,10 +14,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="FluentAssertions.LanguageExt" Version="0.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Dbosoft.Functional.Tests/Dbosoft.Functional.Tests.csproj
+++ b/test/Dbosoft.Functional.Tests/Dbosoft.Functional.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
This PR adds JSON support (`JsonConverter`s) for the LanguageExt `NewType`s.

Closes https://github.com/eryph-org/dotnet-configmodel/issues/91